### PR TITLE
Add collaborative GPT-4 session endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,20 @@ Command:"@w" as ChatGPT and Bing prompt.
 If you would like to contribute to the project, please submit a pull request with your changes. We welcome all contributions!
 # free-wenesday-free
 -- Community-free-Version of WenesdayOS: 1.2.3
+
+## Collaborative GPT-4 Sessions
+
+The project provides experimental collaborative chat sessions powered by GPT-4.
+
+To use this feature, configure an `OPENAI_API_KEY` environment variable before
+starting the Flask application. The following endpoints are available:
+
+- `POST /collab/create` – create a new collaborative session and obtain a
+  `session_id`.
+- `POST /collab/<session_id>/chat` – send a message to the session and receive
+  the model's response along with the updated history.
+- `GET /collab/<session_id>/history` – retrieve the current history of a
+  session.
+
+These endpoints make it easy for multiple clients to share a conversation and
+receive GPT-4 powered responses.

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from app_config import MODEL_PROXY_URLS, FREE_MODEL_RATE_LIMITS  # Import der Ko
 from werkzeug.urls import url_parse  # Use url_parse instead of url_quote
 from models import User
 from auth import auth_bp, init_oauth
+from collaboration import collab_bp
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", os.urandom(24))
@@ -71,6 +72,7 @@ app.register_blueprint(auth_bp, url_prefix='/auth')
 
 # Registriere Admin-Routen
 admin.register_admin_routes(app)
+app.register_blueprint(collab_bp)
 
 # Verfügbare KI-Modelle mit Details
 MODELS = {

--- a/collaboration.py
+++ b/collaboration.py
@@ -1,0 +1,58 @@
+import os
+import uuid
+import requests
+from flask import Blueprint, request, jsonify
+
+# Blueprint for collaborative chat sessions
+collab_bp = Blueprint('collab', __name__)
+
+# In-memory store for chat sessions: {session_id: [messages]}
+collab_sessions = {}
+
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+
+@collab_bp.route('/collab/create', methods=['POST'])
+def create_session():
+    """Create a new collaborative chat session and return its ID."""
+    session_id = str(uuid.uuid4())
+    collab_sessions[session_id] = []
+    return jsonify({"session_id": session_id})
+
+@collab_bp.route('/collab/<session_id>/chat', methods=['POST'])
+def collab_chat(session_id):
+    """Send a message within a collaborative session and get GPT-4 response."""
+    data = request.get_json(silent=True) or request.form
+    message = data.get('message') if data else None
+    if not message:
+        return jsonify({"success": False, "error": "No message provided"}), 400
+
+    history = collab_sessions.setdefault(session_id, [])
+    history.append({"role": "user", "content": message})
+
+    if not OPENAI_API_KEY:
+        return jsonify({"success": False, "error": "Server missing OPENAI_API_KEY"}), 500
+
+    payload = {
+        "model": "gpt-4-turbo",
+        "messages": history,
+    }
+    headers = {
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    api_response = requests.post(OPENAI_API_URL, headers=headers, json=payload)
+    if api_response.status_code == 200:
+        response_data = api_response.json()
+        ai_message = response_data['choices'][0]['message']['content']
+        history.append({"role": "assistant", "content": ai_message})
+        return jsonify({"success": True, "response": ai_message, "history": history})
+    else:
+        error = api_response.json().get('error', {}).get('message', 'Unknown error')
+        return jsonify({"success": False, "error": error}), 500
+
+@collab_bp.route('/collab/<session_id>/history', methods=['GET'])
+def get_history(session_id):
+    """Retrieve the current chat history for a collaborative session."""
+    return jsonify(collab_sessions.get(session_id, []))
+


### PR DESCRIPTION
## Summary
- add `collaboration` blueprint enabling creation of collaborative chat sessions powered by GPT-4
- register collaborative API and document usage in README

## Testing
- `python -m py_compile app.py collaboration.py`
- `pytest` *(fails: ModuleNotFoundError: box2D, MoviePy, and other optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689d2ef23d088332856f3cb97ce8fdfd