### PR TITLE
add community safety foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,13 @@
+---
+name: Security concern
+about: Guidance for responsible security reporting
+title: "[Security]: "
+labels: security
+assignees: ""
+---
+
+Please do not publish vulnerability details, secrets, personal data, exploit code, or live credentials in a public issue.
+
+Report suspected vulnerabilities privately to the repository owner or maintainers through GitHub. Include affected files, endpoints, dependencies, impact, safe reproduction steps, and suggested mitigations where possible.
+
+See `SECURITY.md` for the full policy.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+- 
+
+## Validation
+
+- 
+
+## Privacy, Security, and Ethics Review
+
+- [ ] I considered whether this change processes personal data or sensitive content.
+- [ ] I considered whether this change affects authentication, authorization, secrets, logs, dependencies, or external APIs.
+- [ ] I considered whether this change could enable harmful, discriminatory, or exclusionary outcomes.
+- [ ] I updated documentation where user, operator, privacy, or security expectations changed.
+
+## Notes for Reviewers
+
+- 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in free-wenesday-free respectful, inclusive, and safe for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, sexual identity and orientation, or any other protected or personal characteristic.
+
+Racism, antisemitism, sexism, homophobia, transphobia, ableism, hate speech, harassment, intimidation, and discriminatory behavior are not accepted in this project.
+
+## Expected Behavior
+
+- Use welcoming and inclusive language.
+- Respect different viewpoints, experiences, and identities.
+- Give and receive constructive feedback with care.
+- Accept responsibility, apologize when appropriate, and learn from mistakes.
+- Protect privacy. Do not publish personal data, private messages, credentials, or sensitive information without permission.
+- Report harmful conduct through the project maintainers instead of escalating conflict publicly.
+
+## Unacceptable Behavior
+
+- Hate speech, slurs, dehumanizing language, or symbols of extremist or discriminatory movements.
+- Harassment, stalking, threats, sustained disruption, or unwanted sexual attention.
+- Discrimination or exclusion based on protected characteristics or identity.
+- Publishing private information, credentials, personal data, or security-sensitive details without consent.
+- Abuse of project tools, issues, pull requests, discussions, or automation to target people.
+- Retaliation against someone who reports a concern in good faith.
+
+## Enforcement
+
+Maintainers may remove comments, issues, pull requests, commits, or other contributions that violate this Code of Conduct. Depending on severity and pattern, maintainers may also issue warnings, limit participation, block accounts, or report unlawful behavior to the appropriate platform or authority.
+
+Enforcement should be fair, proportionate, documented where possible, and focused on protecting people and the project.
+
+## Reporting
+
+Report Code of Conduct concerns privately to the repository owner or maintainers through GitHub. If the report involves a maintainer, contact another trusted maintainer where available.
+
+Reports should include:
+
+- What happened.
+- Where it happened.
+- Who was involved.
+- Any links, screenshots, or timestamps that help review the concern.
+- Whether there is an immediate safety or privacy risk.
+
+Maintainers should acknowledge reports when possible, protect reporter privacy, avoid retaliation, and take reasonable action.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+Thank you for contributing to free-wenesday-free. Contributions are welcome when they improve the project and respect the project's privacy, security, ethics, and anti-discrimination commitments.
+
+## Before You Start
+
+Read:
+
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security Policy](SECURITY.md)
+- [Privacy Policy](PRIVACY.md)
+- [Ethics Policy](ETHICS.md)
+
+By participating, you agree to follow these policies.
+
+## Contribution Workflow
+
+1. Fork or branch from `main`.
+2. Create a focused branch with a clear name.
+3. Keep commits small and reviewable.
+4. Do not commit secrets, personal data, session files, generated credentials, dependency folders, or private exports.
+5. Update documentation when behavior, setup, privacy, security, or user impact changes.
+6. Run relevant checks before opening a pull request.
+7. Open a pull request with a clear summary, validation notes, and known risks.
+
+## Pull Request Checklist
+
+- The change has a clear purpose.
+- The diff is limited to the intended scope.
+- Security and privacy impact were considered.
+- User-facing behavior or configuration changes are documented.
+- Relevant tests, builds, linters, or manual checks were run.
+- The change does not introduce discriminatory, hateful, unsafe, or exclusionary behavior.
+
+## Security-Sensitive Changes
+
+Use extra care when changing:
+
+- Authentication or authorization.
+- Session handling.
+- File upload, path handling, or deserialization.
+- Model prompts, AI tool access, or external API calls.
+- Logging, analytics, or telemetry.
+- Dependency installation or build scripts.
+- Storage of user data, messages, prompts, or personal information.
+
+Security vulnerabilities should be reported privately according to [SECURITY.md](SECURITY.md).
+
+## Privacy-Sensitive Changes
+
+If a change collects, stores, logs, displays, exports, or sends user data to a third party, document:
+
+- What data is processed.
+- Why it is necessary.
+- Where it is stored or sent.
+- How long it should be retained.
+- How users or operators can delete it.
+
+## Community Standards
+
+Be kind, direct, and constructive. Challenge ideas with evidence and respect. Do not attack people. Racism, discrimination, harassment, hate speech, and retaliation are not welcome here.

--- a/ETHICS.md
+++ b/ETHICS.md
@@ -1,0 +1,43 @@
+# Ethics Policy
+
+## Purpose
+
+free-wenesday-free should support constructive, lawful, inclusive, and privacy-respecting technology. This policy sets expectations for responsible development, use, and review.
+
+## Core Commitments
+
+- Respect human dignity, human rights, and personal autonomy.
+- Reject racism, hate, discrimination, harassment, and dehumanization.
+- Design for privacy, safety, accessibility, and inclusion.
+- Be transparent about AI-assisted features and meaningful limitations.
+- Keep humans accountable for decisions that affect people.
+- Prefer reversible, explainable, and reviewable changes in sensitive workflows.
+
+## Prohibited Uses
+
+The project must not be used to:
+
+- Promote, automate, or normalize hate, discrimination, harassment, or targeted abuse.
+- Build tools for unlawful surveillance, doxxing, credential theft, or privacy invasion.
+- Facilitate violence, exploitation, coercion, or extremist activity.
+- Make high-impact decisions about people without appropriate human review, lawful basis, and safeguards.
+- Misrepresent AI-generated output as verified human expertise.
+- Process sensitive personal data without necessity, safeguards, and lawful authority.
+
+## AI-Assisted Features
+
+AI features should be treated as assistive and fallible. Contributors should consider:
+
+- What data is sent to models or external providers.
+- Whether prompts, outputs, logs, or tool calls can reveal sensitive information.
+- Whether generated output could produce biased, discriminatory, unsafe, or misleading results.
+- Whether users understand when AI is involved.
+- Whether a human review path exists for sensitive outcomes.
+
+## Accessibility and Inclusion
+
+Contributions should aim to be usable by people with different devices, languages, abilities, and levels of experience. Avoid design or language that excludes people unnecessarily.
+
+## Review and Escalation
+
+When an issue may affect rights, safety, privacy, discrimination, or vulnerable people, pause and request review from maintainers before merging or deploying. Ethics concerns may be reported through the same private maintainer path used for Code of Conduct or security concerns.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,57 @@
+# Privacy Policy
+
+## Purpose
+
+This document sets the privacy baseline for free-wenesday-free. It is written as a project policy, not as individualized legal advice. Deployers and operators are responsible for checking their own legal obligations, including DSGVO/GDPR requirements where applicable.
+
+## Privacy Principles
+
+- Collect only the data needed for a clear project purpose.
+- Prefer anonymous, local, or aggregated data where possible.
+- Do not collect sensitive personal data unless there is a documented need and a lawful basis.
+- Do not commit personal data, user exports, logs, session files, credentials, or API keys to the repository.
+- Make data flows visible in documentation when features process user content.
+- Delete data that is no longer needed.
+- Protect data with appropriate technical and organizational measures.
+
+## Personal Data
+
+Depending on deployment, the application may process:
+
+- Account data such as usernames or email addresses.
+- User-generated content, messages, prompts, algorithm descriptions, or uploaded files.
+- Technical data such as IP addresses, device information, logs, cookies, sessions, or error traces.
+- API usage data from external services used by an operator.
+
+Operators should document which data is actually collected in their deployment, why it is needed, how long it is retained, and who can access it.
+
+## DSGVO/GDPR-Oriented Rights
+
+Where DSGVO/GDPR applies, users may have rights to:
+
+- Access their personal data.
+- Correct inaccurate data.
+- Request deletion.
+- Restrict or object to processing.
+- Receive portable copies of data where applicable.
+- Withdraw consent where consent is the lawful basis.
+
+Project operators should provide a clear contact path for privacy requests and verify requester identity before disclosing or deleting data.
+
+## AI and Third-Party Processing
+
+Some features may use external AI, hosting, analytics, authentication, database, or infrastructure providers. Operators must review provider terms, data processing agreements, retention settings, regional storage, and opt-out controls before sending personal data to third parties.
+
+Do not send secrets, confidential information, or unnecessary personal data to model providers or third-party APIs.
+
+## Cookies, Sessions, and Logs
+
+Use cookies and sessions only where necessary for security, authentication, preferences, or core functionality. Logs should be limited, access-controlled, and scrubbed of sensitive data where possible.
+
+## Data Retention
+
+Retain personal data only for as long as needed for the documented purpose, legal obligations, security investigation, or user-requested functionality. Delete temporary files, generated exports, debug logs, and test data when no longer required.
+
+## Breach Handling
+
+If personal data may have been exposed, maintainers and operators should investigate quickly, preserve relevant evidence, mitigate the issue, and follow applicable notification obligations.

--- a/README.md
+++ b/README.md
@@ -1,75 +1,103 @@
-This repository contains code and files for the "Wenesday" project. Wenesday is a web application that allows users to create and share their favorite recipes, as well as browse recipes from other users.
+# free-wenesday-free
+
+Community-free version of WenesdayOS: 1.2.3
+
+This repository contains code and files for the Wenesday project. Wenesday is an experimental web application and community project for creating, sharing, and browsing algorithms, ideas, and collaborative AI-assisted workflows.
 
 Provider: IT.lopez-be.ch >> lopez.codes >> lopez.zone >> lopez.one
 
-Getting Started:
+## Project Values
 
-This project is a web application called "Wenesday" that allows users to create, share, and browse their favorite algorithms. The application is built using React, React-Router, Redux, Material-UI, and Firebase and includes endpoints that enable the creation, updating, and deletion of algorithms. Users can also search for algorithms and filter them by various criteria. The goal of Wenesday is to create a vibrant community of algorithm enthusiasts and foster the exchange of algorithmic ideas.
+free-wenesday-free is intended to be open, safe, privacy-aware, and inclusive.
 
-If you would like to contribute to the Wenesday project, you can do so by cloning the repository to your local machine. To do this, you will need to have Git installed on your computer. Once you have Git installed, you can clone the repository by running the following command in your terminal:
+- Human dignity, equal treatment, and non-discrimination are core project principles.
+- Racism, antisemitism, sexism, homophobia, transphobia, hate speech, harassment, and exclusionary conduct are not accepted.
+- Privacy and data minimization guide design and operations.
+- Security issues should be reported responsibly and handled with care.
+- AI-assisted features should be transparent, accountable, and reviewed by humans where they can affect people.
 
->> git clone https://github.com/blopen/free-wenesday-free
+Please read the project foundation documents before contributing:
 
-After you have cloned the repository, you can make changes to the code and files as needed. When you are ready to commit your changes, be sure to create a new branch and commit your changes to that branch. Once you have committed your changes, you can submit a pull request to the main branch for review.
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Security Policy](SECURITY.md)
+- [Privacy Policy](PRIVACY.md)
+- [Ethics Policy](ETHICS.md)
 
-Dependencies:
+## Getting Started
 
-React
-React-Router
-Redux
-Material-UI
-Firebase
-TensorFlow
-OpenAI
-Quantum
-GPT-616-Quantinium (alias free-wenesday-free)
-LOPEZ-Modell für emotionale und psychische Gesundheit
+Clone the repository:
 
-License:
+```bash
+git clone https://github.com/blopen/free-wenesday-free
+cd free-wenesday-free
+```
 
-The Wenesday project is licensed under the MIT License. See the LICENSE file for more details.
+Install the project dependencies that match the part of the project you are working on. The repository currently contains Python, web, and experimental AI-related components, so check the relevant files before running services locally.
 
-License Amendment: Purchasing Version Availability for Large Inquiries
+For the base Python application, start by reviewing `requirements.txt`, then configure required environment variables such as `OPENAI_API_KEY` only in a local environment file or secret manager. Do not commit secrets, personal data, API keys, tokens, session files, or generated credentials.
 
-Availability of Purchasing Version for Large Inquiries
-Licensee acknowledges and agrees that the purchasing version of the Software will not be readily available for large inquiries. Licensor shall make reasonable efforts to accommodate Licensee's request for the purchasing version, but such availability is not guaranteed.
+## Contributing
 
-Contact Information
-For further assistance or questions regarding the availability of the purchasing version for large inquiries, Licensee may contact Licensor at https://github.com/blopen, or visit https://it.lopez-be.ch and 
-https://lopez.codes.
+Contributions are welcome when they improve the project while respecting privacy, safety, security, and inclusion.
 
-Effect of Amendment
-This Amendment shall be deemed incorporated into and made a part of the Agreement, and all other terms and conditions of the Agreement shall remain in full force and effect.
+1. Create a feature branch from `main`.
+2. Keep changes focused and easy to review.
+3. Add or update documentation when behavior, configuration, privacy, or security expectations change.
+4. Run relevant local checks before opening a pull request.
+5. Open a pull request and describe the impact, validation, and any risks.
 
-In witness whereof, the parties have executed this Amendment as of the date set forth below.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution workflow.
 
-Contributors:
+## Dependencies
 
-The following people have contributed to the development of the Wensday project:
+The project may include or reference:
 
-@wenesday@W (wenesday@lopez.codes) Nelson Lopez (nelson@it.lopez-be.ch)
+- React
+- React Router
+- Redux
+- Material UI
+- Firebase
+- TensorFlow
+- OpenAI APIs
+- Quantum/experimental components
+- GPT-616-Quantinium alias free-wenesday-free
+- LOPEZ model for emotional and mental health contexts
 
-Command:"@w" as ChatGPT and Bing prompt.
-If you would like to contribute to the project, please submit a pull request with your changes. We welcome all contributions!
-# free-wenesday-free
--- Community-free-Version of WenesdayOS: 1.2.3
+Use dependencies responsibly. Keep them updated, remove unused packages where possible, and avoid adding telemetry or data collection without a documented privacy reason.
 
-## Microservice orchestration guide
+## Security
+
+Report suspected vulnerabilities privately. Do not open public issues containing exploit details, secrets, personal data, or live credentials.
+
+See [SECURITY.md](SECURITY.md) for the disclosure process and secure development expectations.
+
+## Privacy and DSGVO
+
+The project follows privacy-by-design and data-minimization principles. Personal data should only be processed when necessary, documented, protected, and removable on request where legally required.
+
+See [PRIVACY.md](PRIVACY.md) for the DSGVO-oriented privacy baseline.
+
+## Ethics and Anti-Discrimination
+
+The project must not be used to promote hatred, discrimination, harassment, unlawful surveillance, or harm against people or protected groups. Human oversight is required for sensitive use cases, especially where AI-assisted functionality can affect rights, safety, access, or wellbeing.
+
+See [ETHICS.md](ETHICS.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Microservice Orchestration Guide
 
 The application can be containerized and orchestrated as a collection of microservices to reduce coupling and scale independently:
 
-- **Identify bounded contexts**: group related routes and models (for example, the authentication logic in `auth.py` and collaboration endpoints in `collaboration.py`) into separate services with their own data stores.
-- **Isolate service interfaces**: expose only the necessary REST endpoints or message queues for each service. Keep cross-service communication asynchronous where possible to avoid tight coupling.
-- **Centralize shared contracts**: define common schemas and request/response contracts (for example JSON payloads for algorithm metadata) in a shared package that services can import to stay in sync.
+- **Identify bounded contexts**: group related routes and models, for example authentication logic in `auth.py` and collaboration endpoints in `collaboration.py`, into separate services with their own data stores.
+- **Isolate service interfaces**: expose only the necessary REST endpoints or message queues for each service. Keep cross-service communication asynchronous where possible.
+- **Centralize shared contracts**: define common schemas and request/response contracts, for example JSON payloads for algorithm metadata, in a shared package.
 - **Automate builds**: containerize each service with a Dockerfile. A base example lives at the repository root and installs Python dependencies from `requirements.txt` before running `app.py`.
-- **Orchestrate deployments**: use Docker Compose or an orchestrator such as Azure Kubernetes Service to deploy services together. Compose files can specify per-service images, environment variables, and shared networks so that clients can reach each service by name.
-- **Scale clients intelligently**: split large clients into domain-specific front-end bundles or API gateways that forward requests to the appropriate service. This keeps the client lightweight while still supporting the full feature set.
+- **Orchestrate deployments**: use Docker Compose or an orchestrator such as Azure Kubernetes Service to deploy services together.
+- **Scale clients intelligently**: split large clients into domain-specific front-end bundles or API gateways that forward requests to the appropriate service.
 
-### Running the base container locally
+### Running the Base Container Locally
 
-To build and run the monolithic app in a container (as a starting point before splitting services):
-
-```
+```bash
 docker build -t wenesday-app .
 docker run -p 5000:5000 --env OPENAI_API_KEY=your_key_here wenesday-app
 ```
@@ -80,15 +108,28 @@ Once each service has its own Dockerfile, a `docker-compose.yml` can orchestrate
 
 The project provides experimental collaborative chat sessions powered by GPT-4.
 
-To use this feature, configure an `OPENAI_API_KEY` environment variable before
-starting the Flask application. The following endpoints are available:
+Configure an `OPENAI_API_KEY` environment variable before starting the Flask application. The following endpoints are available:
 
-- `POST /collab/create` – create a new collaborative session and obtain a
-  `session_id`.
-- `POST /collab/<session_id>/chat` – send a message to the session and receive
-  the model's response along with the updated history.
-- `GET /collab/<session_id>/history` – retrieve the current history of a
-  session.
+- `POST /collab/create` creates a new collaborative session and returns a `session_id`.
+- `POST /collab/<session_id>/chat` sends a message to the session and returns the model response with updated history.
+- `GET /collab/<session_id>/history` retrieves the current history of a session.
 
-These endpoints make it easy for multiple clients to share a conversation and
-receive GPT-4 powered responses.
+Treat all conversation content as potentially sensitive. Avoid storing unnecessary personal data, and remove test data that is no longer needed.
+
+## License
+
+The Wenesday project is licensed under the MIT License. See the `LICENSE` directory for more details.
+
+### License Amendment: Purchasing Version Availability for Large Inquiries
+
+Licensee acknowledges and agrees that the purchasing version of the Software will not be readily available for large inquiries. Licensor shall make reasonable efforts to accommodate Licensee's request for the purchasing version, but such availability is not guaranteed.
+
+For further assistance or questions regarding the availability of the purchasing version for large inquiries, contact https://github.com/blopen, https://it.lopez-be.ch, or https://lopez.codes.
+
+## Contributors
+
+The following people have contributed to the development of the Wenesday project:
+
+@wenesday@W (wenesday@lopez.codes) Nelson Lopez (nelson@it.lopez-be.ch)
+
+Command: `@w` as ChatGPT and Bing prompt.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Scope
+
+Security reports are welcome for the current default branch and active project code. Experimental, archived, generated, vendored, or third-party code may have different support expectations, but maintainers still welcome responsible reports when project users could be affected.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for suspected vulnerabilities.
+
+Report security concerns privately to the repository owner or maintainers through GitHub. Include enough information to reproduce and assess the issue, but do not include live secrets, personal data, or destructive exploit steps unless maintainers request a safe proof of concept.
+
+Helpful report details:
+
+- Affected file, endpoint, dependency, workflow, or configuration.
+- Impact and likely attacker capability.
+- Reproduction steps in a safe test environment.
+- Whether credentials, personal data, sessions, model prompts, or API keys may be exposed.
+- Suggested mitigation, if known.
+
+## Maintainer Response
+
+Maintainers should aim to:
+
+- Acknowledge credible reports as soon as practical.
+- Triage severity and affected versions.
+- Keep sensitive details private until a fix or mitigation is available.
+- Credit reporters when appropriate and requested.
+- Publish security notes when users need to take action.
+
+## Secure Development Baseline
+
+- Do not commit secrets, API keys, tokens, passwords, private certificates, session stores, or personal data.
+- Keep dependencies updated and remove unused dependencies where possible.
+- Validate and sanitize untrusted input.
+- Use least-privilege access for services, tokens, and integrations.
+- Store secrets in environment variables or a secret manager, not in source control.
+- Protect authentication, authorization, and session handling with extra review.
+- Review AI-assisted features for prompt injection, data leakage, unsafe tool use, and unintended disclosure.
+- Avoid logging sensitive content, credentials, personal data, or private model conversations.
+
+## Disclosure Principles
+
+Coordinated disclosure protects users. Public disclosure should wait until maintainers have had a reasonable opportunity to investigate and mitigate the issue, unless there is an urgent public safety reason.


### PR DESCRIPTION
## Summary

- Adds project foundation documents for code of conduct, security, privacy/DSGVO, ethics, and contributing.
- Updates the README with privacy, security, ethics, anti-racism, and anti-discrimination expectations.
- Adds a pull request template and public security-issue guidance that redirects sensitive reports away from public issues.

## Validation

- Inspected the existing default branch and current README.
- Confirmed the final branch diff is limited to documentation and GitHub templates.
- Used a GitHub tree/commit workflow because Windows cannot check out the existing repository path `bin/swagger.json:Zone.Identifier`.

## Notes

`gh --version` succeeded with `gh version 2.92.0`; `gh auth status` reported no logged-in GitHub hosts in the local CLI, so the connected GitHub app was used for branch and draft PR creation.