### PR TITLE
add EU data and AI governance pack

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-rights-request.md
+++ b/.github/ISSUE_TEMPLATE/data-rights-request.md
@@ -1,0 +1,20 @@
+---
+name: Data rights or privacy request
+about: Guidance for privacy, GDPR/DSGVO, and data subject requests
+title: "[Privacy]: "
+labels: privacy
+assignees: ""
+---
+
+Please do not publish personal data, identification documents, secrets, private messages, access tokens, medical information, or other sensitive content in a public issue.
+
+For personal data access, correction, deletion, portability, objection, restriction, consent withdrawal, or automated-decision concerns, contact the repository owner or deployment operator privately.
+
+Useful non-sensitive context:
+
+- Request type:
+- Deployment or service URL, if applicable:
+- Account or session reference, if safe to share:
+- Date of the issue:
+
+See `docs/compliance/data-subject-request-playbook.md` for the maintainer workflow.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Please read the project foundation documents before contributing:
 - [Privacy Policy](PRIVACY.md)
 - [Ethics Policy](ETHICS.md)
 
+## EU Data and AI Governance
+
+The repository includes a practical governance package for deployments that process personal data, affect real people, or use AI-assisted functionality:
+
+- [EU Data and AI Governance Pack](docs/compliance/README.md)
+- [GDPR Data Protection Pack](docs/compliance/gdpr-data-protection-pack.md)
+- [Data Subject Request Playbook](docs/compliance/data-subject-request-playbook.md)
+- [EU AI Act Readiness Pack](docs/compliance/eu-ai-act-readiness.md)
+- [Human Impact Assessment](docs/compliance/human-impact-assessment.md)
+
+Use these documents before merging or deploying features that collect personal data, rely on AI, classify or recommend content, affect access or opportunity, or create safety, discrimination, privacy, or human-rights risks.
+
 ## Getting Started
 
 Clone the repository:

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,23 @@
+# EU Data and AI Governance Pack
+
+This pack turns the project values into practical operating material for privacy, real people, and AI governance. It is a project baseline, not legal advice. Operators remain responsible for their own jurisdiction, deployment context, data processing records, contracts, and supervisory authority requirements.
+
+## Package Contents
+
+- [GDPR Data Protection Pack](gdpr-data-protection-pack.md): controller/operator checklist, lawful basis mapping, data minimization, retention, DPIA triggers, and breach basics.
+- [Data Subject Request Playbook](data-subject-request-playbook.md): intake and response workflow for access, rectification, erasure, portability, objection, restriction, and consent withdrawal.
+- [EU AI Act Readiness](eu-ai-act-readiness.md): AI Act timeline, role mapping, prohibited practices, GPAI considerations, high-risk triage, AI literacy, and documentation expectations.
+- [Human Impact Assessment](human-impact-assessment.md): real-people review for dignity, discrimination, accessibility, safety, privacy, and human oversight.
+
+## Operating Rule
+
+If a feature processes personal data, affects people, or uses AI to classify, recommend, rank, generate, moderate, infer, or decide something about a person, complete the relevant checklist before merging or deployment.
+
+## Source Baseline
+
+This pack is aligned with public European Commission guidance reviewed on 2026-07-29:
+
+- GDPR information duties and individual rights: https://commission.europa.eu/law/law-topic/data-protection/rules-business-and-organisations/principles-gdpr/what-information-must-be-given-individuals-whose-data-collected_en
+- GDPR individual request handling: https://commission.europa.eu/law/law-topic/data-protection/rules-business-and-organisations/dealing-individuals-requests_en
+- EU AI Act timeline and implementation: https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai
+- AI Act implementation FAQ: https://digital-strategy.ec.europa.eu/en/faqs/navigating-ai-act

--- a/docs/compliance/data-subject-request-playbook.md
+++ b/docs/compliance/data-subject-request-playbook.md
@@ -1,0 +1,88 @@
+# Data Subject Request Playbook
+
+This playbook helps maintainers and operators respond to GDPR/DSGVO rights requests from real people. It is not legal advice. Adapt deadlines, identity checks, and exceptions to the actual deployment and applicable law.
+
+## Supported Request Types
+
+People may request:
+
+- Information about processing.
+- Access to their personal data.
+- Correction of inaccurate or incomplete data.
+- Erasure when data is no longer needed or processing is unlawful.
+- Restriction of processing.
+- Data portability where applicable.
+- Objection to processing.
+- Withdrawal of consent where consent is used.
+- Human review or information about automated decision-making where applicable.
+
+## Response Time
+
+Respond without undue delay and generally within 1 month of receiving a valid request. If the request is complex or numerous requests are made, document any legally available extension and inform the person in time.
+
+## Intake Template
+
+Record:
+
+- Date received.
+- Requester contact.
+- Request type.
+- Relevant account, session, identifier, or context.
+- Identity verification status.
+- Systems to search.
+- Data found.
+- Action taken.
+- Response date.
+- Reviewer.
+- Exceptions or refusal reason, if any.
+
+## Workflow
+
+1. Acknowledge receipt where practical.
+2. Classify the request type.
+3. Verify identity using proportionate information.
+4. Locate relevant systems and processors.
+5. Export, correct, delete, restrict, or explain as appropriate.
+6. Review for third-party data, security secrets, legal holds, or abuse risk.
+7. Respond in clear language.
+8. Log the outcome without storing unnecessary personal data.
+
+## Erasure Checklist
+
+Before deleting, check whether data must be kept for:
+
+- Legal obligations.
+- Security investigation.
+- Establishment, exercise, or defense of legal claims.
+- Freedom of expression or public interest exceptions.
+- Irreversibly anonymized statistical or research purposes where applicable.
+
+If deletion is appropriate:
+
+- Delete primary records.
+- Delete stale sessions and temporary files.
+- Ask processors to delete where required.
+- Remove search indexes or derived records where feasible.
+- Preserve only minimal audit proof of completion.
+
+## AI-Specific Request Handling
+
+When AI features are involved, check:
+
+- Prompts and messages.
+- Generated outputs linked to the person.
+- Conversation history.
+- Embeddings, vectors, indexes, or summaries.
+- Moderation or classification labels.
+- Tool-call logs.
+- Third-party AI provider retention settings.
+
+Do not promise deletion from third-party model training unless the operator has verified the provider terms and controls.
+
+## Refusal or Limitation
+
+If a request is refused or limited, explain the reason, the right to complain to a Data Protection Authority, and available judicial remedies where required.
+
+## Reference
+
+European Commission request-handling guidance reviewed on 2026-07-29: https://commission.europa.eu/law/law-topic/data-protection/rules-business-and-organisations/dealing-individuals-requests_en

--- a/docs/compliance/eu-ai-act-readiness.md
+++ b/docs/compliance/eu-ai-act-readiness.md
@@ -1,0 +1,92 @@
+# EU AI Act Readiness Pack
+
+This document helps free-wenesday-free contributors and operators prepare AI features for the EU AI Act. It is a project readiness checklist, not legal advice.
+
+## Timeline Snapshot
+
+Based on European Commission guidance reviewed on 2026-07-29:
+
+- The AI Act entered into force on 2024-08-01.
+- Prohibited AI practices and AI literacy obligations apply from 2025-02-02.
+- Governance rules and obligations for general-purpose AI models apply from 2025-08-02.
+- The AI Act becomes generally applicable on 2026-08-02, with exceptions.
+- Certain high-risk rules are subject to later transition timelines, including 2027-12-02 for some high-risk use cases and 2028-08-02 for high-risk AI embedded in regulated products, according to Commission implementation guidance available on 2026-07-29.
+
+Always verify current legal status before deployment.
+
+## Role Mapping
+
+For every AI feature, document whether the project/operator acts as:
+
+- Provider: develops or places an AI system/model on the market or puts it into service under its own name.
+- Deployer: uses an AI system under its authority.
+- Importer or distributor: makes another provider's AI system available in the EU.
+- Product manufacturer: embeds AI in a regulated product.
+- General-purpose AI model provider or downstream integrator.
+
+## AI Inventory Template
+
+| Feature | Purpose | AI model/system | Role | People affected | Data used | Risk category | Human oversight | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Collaborative chat | Assist users in shared sessions | External or configured LLM | Deployer or provider, depending on deployment | Session participants | Prompts, messages, outputs | Triage required | User/operator review | Draft |
+
+## Prohibited Practice Triage
+
+Do not build, deploy, or assist features that enable:
+
+- Manipulative or deceptive techniques that materially distort behavior and cause or are likely to cause significant harm.
+- Exploitation of vulnerabilities based on age, disability, or social/economic situation causing or likely to cause significant harm.
+- Social scoring leading to detrimental or unfavorable treatment.
+- Certain biometric categorization, emotion recognition, predictive policing, or untargeted scraping use cases prohibited by the AI Act.
+
+Escalate any feature near these categories before implementation.
+
+## High-Risk Triage
+
+Escalate for legal and maintainer review when AI is used for or materially affects:
+
+- Education or vocational training access, scoring, or evaluation.
+- Employment, worker management, hiring, promotion, termination, or task allocation.
+- Access to essential private or public services.
+- Creditworthiness, insurance, housing, healthcare, benefits, or similar access decisions.
+- Law enforcement, migration, asylum, border control, or justice contexts.
+- Biometric identification or categorization.
+- Safety components in regulated products.
+
+High-risk systems may require risk management, data governance, technical documentation, logging, transparency, human oversight, robustness, accuracy, cybersecurity, conformity assessment, registration, and post-market monitoring.
+
+## AI Literacy
+
+Maintainers and deployers should make sure people configuring, reviewing, or operating AI features understand:
+
+- The intended purpose and limitations.
+- Data protection and confidentiality rules.
+- Prompt injection and unsafe tool-use risks.
+- Bias, discrimination, hallucination, and overreliance risks.
+- When human review is required.
+
+## Transparency and Human Oversight
+
+AI-facing user experiences should make clear when AI is involved, what it can and cannot do, and how people can challenge or correct harmful output. Human oversight must be meaningful for sensitive workflows.
+
+## Documentation Checklist
+
+Before merging AI-impacting changes, document:
+
+- Intended purpose.
+- Model/system used.
+- Role mapping.
+- People affected.
+- Data categories.
+- Risk triage result.
+- Human oversight path.
+- Logging and retention choices.
+- Known limitations.
+- Monitoring and incident response.
+
+## References
+
+European Commission guidance reviewed on 2026-07-29:
+
+- AI Act overview and timeline: https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai
+- Navigating the AI Act FAQ: https://digital-strategy.ec.europa.eu/en/faqs/navigating-ai-act

--- a/docs/compliance/gdpr-data-protection-pack.md
+++ b/docs/compliance/gdpr-data-protection-pack.md
@@ -1,0 +1,114 @@
+# GDPR Data Protection Pack
+
+This document provides a practical GDPR/DSGVO baseline for free-wenesday-free deployments. It is not legal advice. Operators must adapt it to their real processing activities, contracts, jurisdiction, and supervisory authority guidance.
+
+## Core Principles
+
+Use these principles for every feature that processes personal data:
+
+- Lawfulness, fairness, and transparency.
+- Purpose limitation.
+- Data minimization.
+- Accuracy.
+- Storage limitation.
+- Integrity and confidentiality.
+- Accountability.
+
+Personal data means information relating to an identified or identifiable living person. Pseudonymized data can still be personal data when re-identification is possible. Truly anonymous data must be irreversibly anonymized.
+
+## Controller and Operator Checklist
+
+For each deployment, document:
+
+- Controller name and contact path.
+- Data Protection Officer contact, if appointed.
+- Processing purposes.
+- Categories of people affected.
+- Categories of personal data processed.
+- Special category data, if any.
+- Lawful basis for each purpose.
+- Recipients and processors.
+- International transfers and safeguards.
+- Retention period or deletion criteria.
+- Security measures.
+- Data subject request workflow.
+- Breach response workflow.
+
+## Lawful Basis Mapping
+
+Create one row per processing purpose:
+
+| Purpose | Data | People affected | Lawful basis | Retention | Recipients | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Account access | Username, email, auth/session metadata | Registered users | Contract or legitimate interest, depending on deployment | Until account deletion plus operational/legal retention | Hosting/auth providers | Document exact provider flow |
+| Collaborative AI session | Messages, prompts, generated responses, session ID | Session participants | Consent, contract, or legitimate interest, depending on deployment | Minimize; delete stale sessions | AI provider if used | Warn users before external AI processing |
+| Security logs | IP, user agent, timestamps, request metadata | Visitors/users | Legitimate interest | Short operational period | Hosting/security tooling | Avoid logging secrets or message content |
+
+## Transparency Requirements
+
+At or before collection, provide clear information about:
+
+- Who operates the service and how to contact them.
+- Why data is processed.
+- What categories of data are processed.
+- Legal basis.
+- Retention period.
+- Recipients or processor categories.
+- Transfers outside the EU, if any.
+- Data subject rights.
+- Complaint rights with a Data Protection Authority.
+- Consent withdrawal, where consent is used.
+- Automated decision-making, logic involved, and likely consequences, where applicable.
+
+## Special Category and Sensitive Data
+
+Do not intentionally collect sensitive data unless strictly necessary and reviewed. Sensitive categories include health data, biometric identifiers, racial or ethnic origin, political opinions, religious or philosophical beliefs, trade union membership, genetic data, sex life, and sexual orientation.
+
+If a feature may receive sensitive content through free-text prompts or uploads:
+
+- Warn users before submission.
+- Minimize storage.
+- Avoid training or analytics reuse unless explicitly reviewed.
+- Apply access controls and retention limits.
+- Consider a Data Protection Impact Assessment.
+
+## DPIA Triggers
+
+Perform a Data Protection Impact Assessment before deployment when a feature may involve:
+
+- Systematic monitoring of people.
+- Sensitive or special category data.
+- Automated decision-making with significant effects.
+- Large-scale profiling or evaluation.
+- AI-assisted ranking, classification, moderation, recommendation, or inference about people.
+- Children or vulnerable people.
+- New technology with uncertain privacy impact.
+
+## Security Baseline
+
+- Store secrets outside the repository.
+- Restrict access by least privilege.
+- Encrypt transport with HTTPS.
+- Protect sessions and cookies.
+- Avoid logging personal data, prompts, tokens, or generated sensitive content.
+- Review dependencies and remove unused packages.
+- Delete temporary files and debug exports.
+
+## Breach Basics
+
+If personal data may be exposed:
+
+1. Contain the incident.
+2. Preserve relevant evidence.
+3. Identify affected systems, data, and people.
+4. Assess risk to people.
+5. Notify the competent authority and affected people where legally required.
+6. Document facts, effects, and remediation.
+
+## References
+
+European Commission GDPR guidance reviewed on 2026-07-29:
+
+- Information duties: https://commission.europa.eu/law/law-topic/data-protection/rules-business-and-organisations/principles-gdpr/what-information-must-be-given-individuals-whose-data-collected_en
+- GDPR obligations: https://commission.europa.eu/law/law-topic/data-protection/information-business-and-organisations/obligations_en
+- Individual rights: https://commission.europa.eu/law/law-topic/data-protection/reform/rights-citizens/how-my-personal-data-protected/how-should-my-consent-be-requested_en

--- a/docs/compliance/human-impact-assessment.md
+++ b/docs/compliance/human-impact-assessment.md
@@ -1,0 +1,77 @@
+# Human Impact Assessment
+
+Use this assessment before merging or deploying features that affect real people, process personal data, use AI, or influence access, visibility, safety, wellbeing, opportunity, moderation, ranking, or decisions.
+
+## Feature Summary
+
+- Feature name:
+- Owner:
+- Review date:
+- Intended purpose:
+- People affected:
+- Deployment context:
+- AI or automated components:
+- Personal data involved:
+
+## Real People Review
+
+Answer in plain language:
+
+- Who can benefit from this feature?
+- Who can be harmed, excluded, misclassified, surveilled, or pressured?
+- Could this feature affect a person's rights, dignity, reputation, access, safety, work, education, money, health, or housing?
+- Could children, vulnerable people, marginalized groups, or people in crisis be affected?
+- Could the feature amplify racism, discrimination, harassment, or hate?
+
+## Privacy Review
+
+- What personal data is collected or inferred?
+- Is every data field necessary?
+- What is the lawful basis in the deployment context?
+- How long is data retained?
+- Can a person access, correct, delete, restrict, or export their data?
+- Are prompts, outputs, logs, embeddings, or analytics treated as personal data where linked to a person?
+
+## Fairness and Anti-Discrimination Review
+
+- Could outputs differ unfairly by language, race, ethnicity, religion, gender, disability, age, sexuality, class, nationality, or other protected traits?
+- Are there feedback or appeal paths for harmful results?
+- Is human review available before sensitive action is taken?
+- Are moderation and enforcement rules applied consistently?
+
+## AI Safety Review
+
+- Is AI involvement visible to users?
+- What model/system is used?
+- Can users overtrust the output?
+- Can prompt injection or unsafe tool use expose data or trigger harmful actions?
+- Are there limits on high-impact decisions?
+- Are logs monitored for failures without collecting excessive personal data?
+
+## Accessibility Review
+
+- Can people use the feature with assistive technologies?
+- Is the language clear and respectful?
+- Are there alternatives for people who cannot or do not want to use AI features?
+- Does the feature avoid unnecessary friction for people with disabilities or limited technical experience?
+
+## Decision
+
+Choose one:
+
+- Approved.
+- Approved with mitigations.
+- Blocked pending privacy review.
+- Blocked pending security review.
+- Blocked pending ethics review.
+- Blocked pending legal review.
+
+## Required Mitigations
+
+| Risk | Mitigation | Owner | Due date | Status |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Reviewer Notes
+
+Record assumptions, evidence, and unresolved questions. Keep this document with the pull request or release notes when the feature affects people materially.


### PR DESCRIPTION
## Summary

- Adds a practical EU Data and AI Governance Pack under `docs/compliance/`.
- Adds GDPR/DSGVO operational material for data protection, data subject requests, retention, DPIA triggers, breach basics, and AI-related personal data.
- Adds an EU AI Act readiness pack with role mapping, timeline snapshot, prohibited-practice triage, high-risk triage, AI literacy, transparency, and human oversight checks.
- Adds a Human Impact Assessment focused on real people, dignity, discrimination, accessibility, privacy, and safety.
- Adds a privacy/data-rights issue template and links the pack from the README.

## Validation

- Verified the prior community safety foundation is now present on `main`.
- Checked official European Commission guidance for GDPR rights/request handling and EU AI Act application timelines on 2026-07-29.
- Used GitHub app writes because local `git fetch`/checkout is blocked by CLI auth and the repository contains a Windows-invalid `Zone.Identifier` path.

## Sources

- https://commission.europa.eu/law/law-topic/data-protection/rules-business-and-organisations/principles-gdpr/what-information-must-be-given-individuals-whose-data-collected_en
- https://commission.europa.eu/law/law-topic/data-protection/rules-business-and-organisations/dealing-individuals-requests_en
- https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai
- https://digital-strategy.ec.europa.eu/en/faqs/navigating-ai-act